### PR TITLE
Fix installation path errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,8 +38,8 @@
                     "en": "Choose a path for Grocy",
                     "fr": "Choisissez un chemin pour Grocy"
                 },
-                "example": "/",
-                "default": "/"
+                "example": "/custom-path-like-this/",
+                "default": "/grocy/"
             },
             {
                 "name": "language",

--- a/scripts/install
+++ b/scripts/install
@@ -21,7 +21,7 @@ ynh_abort_if_errors
 
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
-path_url=$"/"
+path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
 


### PR DESCRIPTION
Currently Grocy tries to install to the root path of the domain, even 
if the user specifies otherwise #2. These changes fix the issue and 
allow the user to change the path if so desired